### PR TITLE
Fixes '[: ==: unary operator expected'

### DIFF
--- a/clean_kernel.sh
+++ b/clean_kernel.sh
@@ -16,7 +16,7 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
 ##########################################################################
 keep=2
-if [ $1 == "1" ]; then
+if [ "$1" == "1" ]; then
     keep=1
 fi
 OLD=$(ls -tr /boot/vmlinuz-* | head -n -$keep | cut -d- -f2- | awk '{print "linux-image-" $0}')


### PR DESCRIPTION
First off, thanks or this script, just stumbled upon it and it's very useful! :)

Anyways, there's one minor issue with it:

When running clean_kernel.sh, the following error message was displayed:
./clean_kernel.sh: line 19: [: ==: unary operator expected

Even though the script still works, it's a bit irritating, so here's the fix for it.
For more info about why it's needed see:
http://stackoverflow.com/questions/408975/compare-integer-in-bash-unary-operator-expected/605138#605138
